### PR TITLE
[PLATFORM-378]: [Jwks Client]  Cache refactor

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,15 +14,12 @@ readme = "README.md"
 anyhow = "1.0.44"
 async-trait = "0.1.51"
 jsonwebtoken = "8.0.0-beta.2"
-#moka = { version = "0.6.0", features = ["future"] }
 chrono = "0.4"
 reqwest = { version = "0.11", features = ["json"] }
 serde = { version = "1.0", features = ["derive"]}
 serde_json = "1.0"
 thiserror = "1.0.29"
 url = "2.2"
-# TODO: remove this
-tokio = { version = "1.12", features = ["full"] }
 
 [dev-dependencies]
 tokio = { version = "1.11.0", features = ["macros"]}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ readme = "README.md"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+tokio = { version = "1", features = ["sync", "macros"] }
 anyhow = "1.0.44"
 async-trait = "0.1.51"
 jsonwebtoken = "8.0.0-beta.2"
@@ -22,7 +23,6 @@ thiserror = "1.0.29"
 url = "2.2"
 
 [dev-dependencies]
-tokio = { version = "1.11.0", features = ["macros"]}
 mockall = "0.10"
 httpmock = "0.6"
 rand = "0.8"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,17 +14,21 @@ readme = "README.md"
 anyhow = "1.0.44"
 async-trait = "0.1.51"
 jsonwebtoken = "8.0.0-beta.2"
-moka = { version = "0.6.0", features = ["future"] }
+#moka = { version = "0.6.0", features = ["future"] }
+chrono = "0.4"
 reqwest = { version = "0.11", features = ["json"] }
 serde = { version = "1.0", features = ["derive"]}
 serde_json = "1.0"
 thiserror = "1.0.29"
 url = "2.2"
+# TODO: remove this
+tokio = { version = "1.12", features = ["full"] }
 
 [dev-dependencies]
 tokio = { version = "1.11.0", features = ["macros"]}
 mockall = "0.10"
 httpmock = "0.6"
+rand = "0.8"
 
 [[example]]
 name = "get_jwks"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jwks_client_rs"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 authors = ["Mite Ristovski <mite.ristovski@hotmail.com>", "Simone Cottini <cottini.simone@gmail.com>"]
 license = "MIT"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jwks_client_rs"
-version = "0.2.1"
+version = "0.3.0"
 edition = "2021"
 authors = ["Mite Ristovski <mite.ristovski@hotmail.com>", "Simone Cottini <cottini.simone@gmail.com>"]
 license = "MIT"

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -14,7 +14,7 @@ args = [
 
 [tasks.test]
 command = "cargo"
-args = ["test"]
+args = ["test", "${@}"]
 
 [tasks.clippy]
 command = "cargo"

--- a/examples/get_jwks.rs
+++ b/examples/get_jwks.rs
@@ -1,4 +1,5 @@
 use std::str::FromStr;
+use std::time::Duration;
 
 use reqwest::Url;
 
@@ -21,7 +22,11 @@ async fn main() {
         .build(url)
         .expect("Failed to build WebSource");
 
-    let client: JwksClient<WebSource> = JwksClient::new(source);
+    let time_to_live: Duration = Duration::from_secs(60);
+
+    let client: JwksClient<WebSource> = JwksClient::builder()
+        .time_to_live(time_to_live)
+        .build(source);
 
     // The kid "unknown" cannot be a JWKS valid KID. This must not be found here
     let result: Result<JsonWebKey, JwksClientError> = client.get("unknown".to_string()).await;

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -1,11 +1,13 @@
-use crate::source::JwksSource;
-use crate::JwksClient;
 use std::marker::PhantomData;
 use std::time::Duration;
+
+use crate::source::JwksSource;
+use crate::JwksClient;
 
 pub struct JwksClientBuilder<T> {
     ttl_opt: Option<Duration>,
     t: PhantomData<T>,
+    // New PR to add this?
     // cache_size: Option<usize>,
 }
 

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -6,7 +6,7 @@ use crate::JwksClient;
 
 pub struct JwksClientBuilder<T> {
     ttl_opt: Option<Duration>,
-    t: PhantomData<T>,
+    t: PhantomData<*const T>,
     // New PR to add this?
     // cache_size: Option<usize>,
 }
@@ -26,6 +26,7 @@ impl<T: JwksSource + Send + Sync + 'static> JwksClientBuilder<T> {
         }
     }
 
+    #[must_use]
     pub fn build(self, source: T) -> JwksClient<T> {
         JwksClient::new(source, self.ttl_opt)
     }

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -1,0 +1,30 @@
+use crate::source::JwksSource;
+use crate::JwksClient;
+use std::marker::PhantomData;
+use std::time::Duration;
+
+pub struct JwksClientBuilder<T> {
+    ttl_opt: Option<Duration>,
+    t: PhantomData<T>,
+    // cache_size: Option<usize>,
+}
+
+impl<T: JwksSource + Send + Sync + 'static> JwksClientBuilder<T> {
+    pub(crate) fn new() -> Self {
+        Self {
+            ttl_opt: None,
+            t: PhantomData::default(),
+        }
+    }
+
+    pub fn time_to_live(&self, ttl: Duration) -> Self {
+        Self {
+            ttl_opt: Some(ttl),
+            t: PhantomData::default(),
+        }
+    }
+
+    pub fn build(self, source: T) -> JwksClient<T> {
+        JwksClient::new(source, self.ttl_opt)
+    }
+}

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -61,7 +61,7 @@ impl Cache {
     {
         let mut guard: RwLockWriteGuard<Entry> = self.inner.write().await;
         let _ = self.refreshed.swap(false, Ordering::Relaxed);
-        
+
         if !self.refreshed.load(Ordering::SeqCst) {
             let set: JsonWebKeySet = future.await?;
             *guard = Entry::new(set.clone(), &self.time_to_live);

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -1,0 +1,94 @@
+use std::collections::HashMap;
+use std::future::Future;
+use std::hash::Hash;
+use std::sync::{Arc, Mutex, MutexGuard, PoisonError, RwLock, RwLockReadGuard, RwLockWriteGuard};
+use std::time::Duration as StdDuration;
+
+use chrono::{Duration, Utc};
+
+type Map<K, V> = HashMap<K, Mutex<Entry<V>>>;
+
+#[derive(Clone)]
+pub(crate) struct Cache<K, V> {
+    inner: Arc<RwLock<Map<K, V>>>,
+    time_to_live: Duration,
+}
+
+impl<K: Clone + Eq + Hash, V: Clone> Cache<K, V> {
+    pub fn new(time_to_live: StdDuration) -> Self {
+        Self {
+            inner: Arc::new(RwLock::new(HashMap::new())),
+            time_to_live: Duration::from_std(time_to_live)
+                .expect("Failed to convert from `std::time::Duration` to `chrono::Duration`"),
+        }
+    }
+
+    pub async fn get_or_try_insert_with<F, E, O>(&self, key: &K, update_fn: F) -> Result<V, E>
+    where
+        F: FnOnce() -> O,
+        O: Future<Output = Result<V, E>> + Send + 'static,
+        E: Send + Sync + 'static,
+    {
+        let read: RwLockReadGuard<Map<K, V>> =
+            self.inner.read().unwrap_or_else(PoisonError::into_inner);
+
+        let value: V = match read.get(key) {
+            None => {
+                // Drop RwLock read guard prematurely to be able to write in the lock
+                drop(read);
+                let v: V = update_fn().await?;
+                self.put::<E>(key, &v)?;
+                v
+            }
+            Some(mutex) => {
+                let mut guard: MutexGuard<Entry<V>> =
+                    mutex.lock().unwrap_or_else(PoisonError::into_inner);
+
+                if guard.is_expired() {
+                    match update_fn().await {
+                        Ok(value) => {
+                            // Update guard with new value caught from remote
+                            *guard = Entry::new(&value, &self.time_to_live);
+                            value
+                        }
+                        Err(_) => guard.value.clone(),
+                    }
+                } else {
+                    guard.value.clone()
+                }
+            }
+        };
+
+        Ok(value)
+    }
+
+    fn put<E>(&self, key: &K, value: &V) -> Result<Option<Mutex<Entry<V>>>, E>
+    where
+        E: Send + Sync + 'static,
+    {
+        let mut guard: RwLockWriteGuard<HashMap<K, Mutex<Entry<V>>>> =
+            self.inner.write().unwrap_or_else(PoisonError::into_inner);
+        Ok((*guard).insert(
+            key.clone(),
+            Mutex::new(Entry::new(value, &self.time_to_live)),
+        ))
+    }
+}
+
+pub(crate) struct Entry<V> {
+    value: V,
+    expire_time_millis: i64,
+}
+
+impl<V: Clone> Entry<V> {
+    fn new(value: &V, expiration: &Duration) -> Self {
+        Self {
+            value: value.clone(),
+            expire_time_millis: Utc::now().timestamp_millis() + expiration.num_milliseconds(),
+        }
+    }
+
+    fn is_expired(&self) -> bool {
+        Utc::now().timestamp_millis() > self.expire_time_millis
+    }
+}

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -60,12 +60,12 @@ impl Cache {
         F: Future<Output = Result<JsonWebKeySet, Error>> + Send + 'static,
     {
         let mut guard: RwLockWriteGuard<Entry> = self.inner.write().await;
-        self.refreshed.store(false, Ordering::Relaxed);
+        self.refreshed.store(false, Ordering::SeqCst);
 
         if !self.refreshed.load(Ordering::SeqCst) {
             let set: JsonWebKeySet = future.await?;
             *guard = Entry::new(set.clone(), &self.time_to_live);
-            self.refreshed.store(true, Ordering::Relaxed);
+            self.refreshed.store(true, Ordering::SeqCst);
             Ok(set)
         } else {
             Ok((*guard).set.clone())

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -60,12 +60,12 @@ impl Cache {
         F: Future<Output = Result<JsonWebKeySet, Error>> + Send + 'static,
     {
         let mut guard: RwLockWriteGuard<Entry> = self.inner.write().await;
-        let _ = self.refreshed.swap(false, Ordering::Relaxed);
+        self.refreshed.store(false, Ordering::Relaxed);
 
         if !self.refreshed.load(Ordering::SeqCst) {
             let set: JsonWebKeySet = future.await?;
             *guard = Entry::new(set.clone(), &self.time_to_live);
-            let _ = self.refreshed.swap(true, Ordering::Relaxed);
+            self.refreshed.store(true, Ordering::Relaxed);
             Ok(set)
         } else {
             Ok((*guard).set.clone())

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -59,8 +59,8 @@ impl Cache {
     where
         F: Future<Output = Result<JsonWebKeySet, Error>> + Send + 'static,
     {
-        let mut guard: RwLockWriteGuard<Entry> = self.inner.write().await;
         self.refreshed.store(false, Ordering::SeqCst);
+        let mut guard: RwLockWriteGuard<Entry> = self.inner.write().await;
 
         if !self.refreshed.load(Ordering::SeqCst) {
             let set: JsonWebKeySet = future.await?;

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -1,15 +1,17 @@
 use std::collections::HashMap;
 use std::future::Future;
 use std::hash::Hash;
-use std::sync::{Arc, Mutex, MutexGuard, PoisonError, RwLock, RwLockReadGuard, RwLockWriteGuard};
+use std::sync::Arc;
 use std::time::Duration as StdDuration;
 
 use chrono::{Duration, Utc};
+use tokio::sync::RwLock;
+use tokio::sync::{Mutex, MutexGuard, RwLockReadGuard, RwLockWriteGuard};
 
 type Map<K, V> = HashMap<K, Mutex<Entry<V>>>;
 
 #[derive(Clone)]
-pub(crate) struct Cache<K, V> {
+pub struct Cache<K, V> {
     inner: Arc<RwLock<Map<K, V>>>,
     time_to_live: Duration,
 }
@@ -23,29 +25,26 @@ impl<K: Clone + Eq + Hash, V: Clone> Cache<K, V> {
         }
     }
 
-    pub async fn get_or_try_insert_with<F, E, O>(&self, key: &K, update_fn: F) -> Result<V, E>
+    pub async fn get_or_try_insert_with<F, E>(&self, key: &K, future: F) -> Result<V, E>
     where
-        F: FnOnce() -> O,
-        O: Future<Output = Result<V, E>> + Send + 'static,
+        F: Future<Output = Result<V, E>> + Send + 'static,
         E: Send + Sync + 'static,
     {
-        let read: RwLockReadGuard<Map<K, V>> =
-            self.inner.read().unwrap_or_else(PoisonError::into_inner);
+        let read: RwLockReadGuard<Map<K, V>> = self.inner.read().await;
 
         let value: V = match read.get(key) {
             None => {
                 // Drop RwLock read guard prematurely to be able to write in the lock
                 drop(read);
-                let v: V = update_fn().await?;
-                self.put::<E>(key, &v)?;
+                let v: V = future.await?;
+                self.put::<E>(key, &v).await?;
                 v
             }
             Some(mutex) => {
-                let mut guard: MutexGuard<Entry<V>> =
-                    mutex.lock().unwrap_or_else(PoisonError::into_inner);
+                let mut guard: MutexGuard<Entry<V>> = mutex.lock().await;
 
                 if guard.is_expired() {
-                    match update_fn().await {
+                    match future.await {
                         Ok(value) => {
                             // Update guard with new value caught from remote
                             *guard = Entry::new(&value, &self.time_to_live);
@@ -62,12 +61,12 @@ impl<K: Clone + Eq + Hash, V: Clone> Cache<K, V> {
         Ok(value)
     }
 
-    fn put<E>(&self, key: &K, value: &V) -> Result<Option<Mutex<Entry<V>>>, E>
+    async fn put<E>(&self, key: &K, value: &V) -> Result<Option<Mutex<Entry<V>>>, E>
     where
         E: Send + Sync + 'static,
     {
-        let mut guard: RwLockWriteGuard<HashMap<K, Mutex<Entry<V>>>> =
-            self.inner.write().unwrap_or_else(PoisonError::into_inner);
+        let mut guard: RwLockWriteGuard<HashMap<K, Mutex<Entry<V>>>> = self.inner.write().await;
+
         Ok((*guard).insert(
             key.clone(),
             Mutex::new(Entry::new(value, &self.time_to_live)),

--- a/src/client.rs
+++ b/src/client.rs
@@ -48,7 +48,7 @@ impl<T: JwksSource + Send + Sync + 'static> JwksClient<T> {
 
         let key: JsonWebKey = self
             .cache
-            .get_or_refresh(&key_id.clone(), async move { source.fetch_keys().await })
+            .get_or_refresh(&key_id, async move { source.fetch_keys().await })
             .await?;
 
         Ok(key)

--- a/src/client.rs
+++ b/src/client.rs
@@ -44,11 +44,11 @@ impl<T: JwksSource + Send + Sync + 'static> JwksClient<T> {
     /// Retrieves the key from the cache, if not found it fetches it from the provided `source`.
     /// If the key is not found after fetching it, returns an error.
     pub async fn get(&self, key_id: String) -> Result<JsonWebKey, JwksClientError> {
-        let source = self.source.clone();
+        let source: Arc<T> = self.source.clone();
 
-        let key = self
+        let key: JsonWebKey = self
             .cache
-            .get_or_try_insert_with(&key_id.clone(), || async move {
+            .get_or_try_insert_with(&key_id.clone(), async move {
                 source.fetch_keys().await?.take_key(&key_id)
             })
             .await?;

--- a/src/client.rs
+++ b/src/client.rs
@@ -2,16 +2,15 @@ use std::str::FromStr;
 use std::sync::Arc;
 use std::time::Duration;
 
+use crate::builder::JwksClientBuilder;
 use jsonwebtoken::{Algorithm, DecodingKey, Validation};
-use moka::future::{Cache, CacheBuilder};
 use serde::de::DeserializeOwned;
 
+use crate::cache::Cache;
 use crate::error::{Error, JwksClientError};
 use crate::keyset::JsonWebKey;
 use crate::source::JwksSource;
 
-const DEFAULT_CACHE_SIZE: usize = 100;
-//TODO: we can also use auth0 response cache-control headers instead of this const (1 day)
 const DEFAULT_CACHE_TTL: Duration = Duration::from_secs(86400);
 
 pub struct JwksClient<T: JwksSource> {
@@ -31,13 +30,15 @@ impl<T: JwksSource> Clone for JwksClient<T> {
 impl<T: JwksSource + Send + Sync + 'static> JwksClient<T> {
     /// Constructs the client.
     /// This should be cloned when passed to threads.
-    pub fn new(source: T) -> Self {
+    pub(crate) fn new(source: T, ttl_opt: Option<Duration>) -> Self {
         Self {
             source: Arc::new(source),
-            cache: CacheBuilder::new(DEFAULT_CACHE_SIZE)
-                .time_to_live(DEFAULT_CACHE_TTL)
-                .build(),
+            cache: Cache::new(ttl_opt.unwrap_or(DEFAULT_CACHE_TTL)),
         }
+    }
+
+    pub fn builder() -> JwksClientBuilder<T> {
+        JwksClientBuilder::new()
     }
 
     /// Retrieves the key from the cache, if not found it fetches it from the provided `source`.
@@ -47,7 +48,7 @@ impl<T: JwksSource + Send + Sync + 'static> JwksClient<T> {
 
         let key = self
             .cache
-            .get_or_try_insert_with(key_id.clone(), async move {
+            .get_or_try_insert_with(&key_id.clone(), || async move {
                 source.fetch_keys().await?.take_key(&key_id)
             })
             .await?;
@@ -106,6 +107,7 @@ mod test {
     use httpmock::prelude::*;
     use jsonwebtoken::{Algorithm, EncodingKey, Header};
     use serde_json::{json, Value};
+    use std::time::Duration;
     use url::Url;
 
     use crate::error::Error;
@@ -131,9 +133,77 @@ mod test {
 
         let url: Url = Url::parse(&server.url(path)).unwrap();
         let source: WebSource = WebSource::builder().build(url).unwrap();
-        let client: JwksClient<WebSource> = JwksClient::new(source);
+        let client: JwksClient<WebSource> = JwksClient::new(source, None);
 
         assert!(client.get(kid.to_string()).await.is_ok());
+        mock.assert();
+    }
+
+    #[tokio::test]
+    async fn get_key_after_expiration_should_update() {
+        let server = MockServer::start();
+        let path: &str = "/keys";
+        let kid: &str = "go14h7EBWUvPRncjniI_2";
+
+        let mut mock = server.mock(|when, then| {
+            when.method(GET).path(path);
+
+            then.status(200)
+                .header("content-type", "application/json")
+                .json_body(jwks_endpoint_response(kid));
+        });
+
+        let url: Url = Url::parse(&server.url(path)).unwrap();
+        let source: WebSource = WebSource::builder().build(url).unwrap();
+        let ttl_opt: Option<Duration> = Some(Duration::from_millis(1));
+        let client: JwksClient<WebSource> = JwksClient::new(source, ttl_opt);
+
+        let result_key_1 = client.get(kid.to_string()).await;
+        assert!(result_key_1.is_ok());
+        let x5t_1: String = result_key_1.unwrap().x5t().unwrap();
+
+        mock.assert();
+        mock.delete();
+
+        // This test that if the key is expired a new call to remote endpoint is performed.
+
+        // Give time to let the keys expire
+        std::thread::sleep(Duration::from_millis(2));
+
+        let mut mock = server.mock(|when, then| {
+            when.method(GET).path(path);
+
+            then.status(200)
+                .header("content-type", "application/json")
+                .json_body(jwks_endpoint_response(kid));
+        });
+
+        let result_key_2 = client.get(kid.to_string()).await;
+        assert!(result_key_2.is_ok());
+        let x5t_2: String = result_key_2.unwrap().x5t().unwrap();
+
+        assert_ne!(x5t_1, x5t_2);
+
+        mock.assert();
+        mock.delete();
+
+        // This test that if the key is expired but the remote call fails the value is
+        // still the same
+
+        // Give time to let the keys expire
+        std::thread::sleep(Duration::from_millis(2));
+
+        let mock = server.mock(|when, then| {
+            when.method(GET).path(path);
+            then.status(400).body("Error");
+        });
+
+        let result_key_3 = client.get(kid.to_string()).await;
+        assert!(result_key_3.is_ok());
+        let x5t_3: String = result_key_3.unwrap().x5t().unwrap();
+
+        assert_eq!(x5t_2, x5t_3);
+
         mock.assert();
     }
 
@@ -151,7 +221,7 @@ mod test {
 
         let url: Url = Url::parse(&server.url(path)).unwrap();
         let source: WebSource = WebSource::builder().build(url).unwrap();
-        let client: JwksClient<WebSource> = JwksClient::new(source);
+        let client: JwksClient<WebSource> = JwksClient::new(source, None);
 
         let result = client.get(kid.to_string()).await;
         assert!(result.is_err());
@@ -183,7 +253,7 @@ mod test {
 
         let url: Url = Url::parse(&server.url(path)).unwrap();
         let source: WebSource = WebSource::builder().build(url).unwrap();
-        let client: JwksClient<WebSource> = JwksClient::new(source);
+        let client: JwksClient<WebSource> = JwksClient::new(source, None);
 
         let result = client.get(kid.to_string()).await;
         assert!(result.is_err());
@@ -203,7 +273,7 @@ mod test {
     #[tokio::test]
     async fn decode_missing_kid_in_header() {
         let source = crate::source::MockJwksSource::new();
-        let client = JwksClient::new(source);
+        let client = JwksClient::new(source, None);
 
         // pem generated using: ssh-keygen -t rsa -b 4096 -m PEM -f jwtRS256.key
         let encoding_key = EncodingKey::from_rsa_pem(
@@ -304,7 +374,7 @@ SQ1D7EfH/F2wy7Sj9YrRqTIgxk+gmk5T9d/iNwhIFdMnWRBQpt6h1H0T4t0WTA==
                   "n": MODULUS,
                   "e": EXPONENT,
                   "kid": kid,
-                  "x5t": "dfrlEXMuWrPaCbmIrpXaiwNjFf4",
+                  "x5t": random_string(),
                   "x5c": [
                     "MIIDDTCCAfWgAwIBAgIJWUyDuZMhkTwpMA0GCSqGSIb3DQEBCwUAMCQxIjAgBgNVBAMTGWRldi1mOHJkejF3dy5ldS5hdXRoMC5jb20wHhcNMjEwOTA2MDkxODQ0WhcNMzUwNTE2MDkxODQ0WjAkMSIwIAYDVQQDExlkZXYtZjhyZHoxd3cuZXUuYXV0aDAuY29tMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAqjNzuylUQpyU9qX3/bMGpiRUO1G/xKbB0fyqQy0naETviHIqPS2D3lGcfK9XIFLZOq1O7K2KRXEE5nSDTf+S9qc0nPRkS38CXK4DBKPTBXtjufLK3e9lN9dh8Ehazx8xNmdCc6aocVKKlamOJv7Qr/UgmoFllq7W+UQ0YK2qfN8WgqxOQUPrss+40RWslCAKpjZmMOpIpRXQLGmR+GGZUdQZXnTUhnhRyDz5VcXHH++o1PkH/F0rlabMxgNFfsCIWKWbGy8G89bNrvoeVKq15QPCeaGBV13f2Do6XHGt0l2M3eYz85wyz1pISvjQuR4PrtJr6VsuHz3Puh/KgY8GqQIDAQABo0IwQDAPBgNVHRMBAf8EBTADAQH/MB0GA1UdDgQWBBQ1uIfkGnNThAvMeJzxnOYxn+w5iDAOBgNVHQ8BAf8EBAMCAoQwDQYJKoZIhvcNAQELBQADggEBADE2QQ3SL4mMIzF4Y63TI+KfD9TOQGSqxmavU5jMYhzlDsQpSR8CyK4Nl6wgVNJuESeXCNcOdBTtViQJ5PmUPkEaswCfI2qufWM44tKkKNhKdgh15Dzq6e0LK8oeadA6OdADnz9QvTaHU7VIxpi2swJEPtlmMb58wkkVhxLAtVtLNp90fbE0EQstBbQWcgodjOOQXmOJlCyIOCmvkBcbUkQSXt66Yn/GTU2jvco0U5yBzLHSOANSfi5GQIdzlSNFmdbq057Zc/GivQAEL4adPQPHeAgDZvnarvX+UqU8lp/yuNOycJ24SRnRTcCqeNB0kjybYLTgOedv/E6D2RGvF2E="
                   ]
@@ -312,5 +382,14 @@ SQ1D7EfH/F2wy7Sj9YrRqTIgxk+gmk5T9d/iNwhIFdMnWRBQpt6h1H0T4t0WTA==
               ]
             }
         )
+    }
+
+    fn random_string() -> String {
+        use rand::{distributions::Alphanumeric, Rng};
+        rand::thread_rng()
+            .sample_iter(&Alphanumeric)
+            .take(7)
+            .map(char::from)
+            .collect()
     }
 }

--- a/src/client.rs
+++ b/src/client.rs
@@ -2,10 +2,10 @@ use std::str::FromStr;
 use std::sync::Arc;
 use std::time::Duration;
 
-use crate::builder::JwksClientBuilder;
 use jsonwebtoken::{Algorithm, DecodingKey, Validation};
 use serde::de::DeserializeOwned;
 
+use crate::builder::JwksClientBuilder;
 use crate::cache::Cache;
 use crate::error::{Error, JwksClientError};
 use crate::keyset::JsonWebKey;
@@ -104,10 +104,11 @@ impl<T: JwksSource + Send + Sync + 'static> JwksClient<T> {
 
 #[cfg(test)]
 mod test {
+    use std::time::Duration;
+
     use httpmock::prelude::*;
     use jsonwebtoken::{Algorithm, EncodingKey, Header};
     use serde_json::{json, Value};
-    use std::time::Duration;
     use url::Url;
 
     use crate::error::Error;

--- a/src/keyset.rs
+++ b/src/keyset.rs
@@ -55,6 +55,13 @@ impl JsonWebKey {
             JsonWebKey::Rsa(rsa_pk) => Ok(rsa_pk),
         }
     }
+
+    #[cfg(test)]
+    pub fn x5t(&self) -> Option<String> {
+        match self {
+            JsonWebKey::Rsa(rsa_pk) => rsa_pk.x5t.clone(),
+        }
+    }
 }
 
 #[derive(Debug, Deserialize, Clone)]
@@ -67,6 +74,8 @@ pub struct RsaPublicJwk {
     // X.509 certificate chain
     #[serde(rename(deserialize = "x5c"))]
     certificates: Option<Vec<String>>,
+    #[cfg(test)]
+    x5t: Option<String>,
     #[serde(rename(deserialize = "n"))]
     modulus: String,
     #[serde(rename(deserialize = "e"))]

--- a/src/keyset.rs
+++ b/src/keyset.rs
@@ -10,6 +10,10 @@ pub struct JsonWebKeySet {
 }
 
 impl JsonWebKeySet {
+    pub(crate) fn empty() -> Self {
+        Self { keys: vec![] }
+    }
+
     pub fn get_key(&self, key_id: &str) -> Result<&JsonWebKey, Error> {
         self.keys
             .iter()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,8 @@ pub use client::JwksClient;
 pub use error::JwksClientError;
 pub use keyset::JsonWebKey;
 
+mod builder;
+mod cache;
 mod client;
 mod error;
 mod keyset;


### PR DESCRIPTION
https://prima-assicurazioni-spa.myjetbrains.com/youtrack/issue/PLATFORM-378

With this PR the logic of how this library works has changed.

- All expired entries are not removed anymore from the cache but are logically expired. When that value is requested by the client the update_fn tries to sync the remote jwks with local cached values. If this operation is fine the value is saved in the cache with a new expiration date (based on cache ttl). If it fails the previous value is kept in memory with older expiry date.
- Implemented JwksClient builder pattern. Now instead of JwksClient::new use JwksClient::builder

Could be useful to add a new config that tells the cache, when the key update fails, how long keep the value in memory before a retry (atm everytime a client fetch that value by key a new http call to remote jwks is done)

