### PR TITLE
Add is_jwt_expired method on Error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /target
 Cargo.lock
+.idea

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Is now possible to know if the error is caused by expired jwt (useful for refreshing purposes)
+
 ### Fixed
 
 - README code example updated with the latest changes.

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,4 +1,5 @@
 use std::sync::Arc;
+use jsonwebtoken::errors::ErrorKind;
 
 #[derive(thiserror::Error, Debug)]
 pub enum Error {
@@ -27,5 +28,20 @@ impl From<Error> for JwksClientError {
 impl From<jsonwebtoken::errors::Error> for JwksClientError {
     fn from(error: jsonwebtoken::errors::Error) -> Self {
         Self::Error(Arc::new(error.into()))
+    }
+}
+
+impl JwksClientError {
+    pub fn is_jwt_expired(&self) -> bool {
+        match self { JwksClientError::Error(e) => { e.is_jwt_expired() } }
+    }
+}
+
+impl Error {
+    fn is_jwt_expired(&self) -> bool {
+        match self {
+            Error::JsonWebToken(err) => { matches!(err.kind(), ErrorKind::ExpiredSignature) }
+            _ => false
+        }
     }
 }


### PR DESCRIPTION
Users must be able to know if the reason of the error was an expired jwt if they want to trigger a refresh mechanism, I simply added check methods on the errors, alternatively we could expose the inner `Error` enum.