### PR TITLE
Allow user to get url for web source

### DIFF
--- a/src/source.rs
+++ b/src/source.rs
@@ -25,6 +25,10 @@ impl WebSource {
     pub fn builder() -> WebSourceBuilder {
         WebSourceBuilder::new()
     }
+
+    pub fn url(&self) -> &Url {
+        &self.url
+    }
 }
 
 #[async_trait]


### PR DESCRIPTION
When implementing a custom source that wraps web source, I'd like to be able to retrieve the url of the web source. This is useful so I can cleanly log which web source is returning an error when there are multiple.