### PR TITLE
Public docker image to Pull-Through cache

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.96
+FROM 279066465364.dkr.ecr.eu-west-1.amazonaws.com/docker-hub/library/rust:1.96
 
 WORKDIR /code
 


### PR DESCRIPTION
With this automated PR we want to migrate toward a pull-through cache repository.

A pull-through cache is an AWS ECR repository that transparently proxies and
caches images from an upstream public registry (Docker Hub, GHCR, Quay, ...).
The first pull fetches the image from the upstream registry and stores a copy in
our own ECR; every subsequent pull is served straight from ECR. This removes our
build- and deploy-time dependency on public registries, protects us from Docker
Hub rate limits and public-registry outages, and keeps a cached copy of every
image under our control.

This PR rewrites the `FROM` instructions in this repository's Dockerfiles so the
same images (same tags) are pulled through our ECR pull-through cache instead of
directly from the public registry.

This is a link to our doc: https://app.notion.com/p/helloprima/AWS-ECR-184405dec57b807f9cbcc0b79000abf1#23a405dec57b80fa81fcdde544d4e47c
